### PR TITLE
Add sample for custom BOMStructure and Where Used

### DIFF
--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_Part_tgv_Separator.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_Part_tgv_Separator.xml
@@ -1,0 +1,5 @@
+﻿<AML>
+ <Item type="CommandBarSeparator" id="63FBF765CBF54E2B829AFB394E1538DB" action="add">
+  <name>EXT_Part_tgv_Separator</name>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_mwt_Part_tgv_StructureBrowser.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_mwt_Part_tgv_StructureBrowser.xml
@@ -1,0 +1,12 @@
+﻿<AML>
+ <Item type="CommandBarButton" id="1217C91077AD4928B95F923C1B06660D" action="add">
+  <additional_data>{ "cui_disabled": "true" }</additional_data>
+  <image>../Images/BlockInternal.svg</image>
+  <include_events>SelectInToc,SelectInGrid</include_events>
+  <label xml:lang="en">Structure Browser</label>
+  <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">195EB07305C247ACA7116CD3A03FD3E1</on_click_handler>
+  <on_init_handler keyed_name="EXT_TGV_Part_BOMStructure_Reinit" type="Method">DD6F4C2385CE48A18B71D2C70622F2B0</on_init_handler>
+  <tooltip_template xml:lang="en">Show Part structure</tooltip_template>
+  <name>EXT_mwt_Part_tgv_StructureBrowser</name>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_mwt_Part_tgv_StructureBrowser.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_mwt_Part_tgv_StructureBrowser.xml
@@ -4,7 +4,7 @@
   <image>../Images/BlockInternal.svg</image>
   <include_events>SelectInToc,SelectInGrid</include_events>
   <label xml:lang="en">Structure Browser</label>
-  <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">195EB07305C247ACA7116CD3A03FD3E1</on_click_handler>
+  <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">072E8757D8674E4EB7BD27F04463472E</on_click_handler>
   <on_init_handler keyed_name="EXT_TGV_Part_BOMStructure_Reinit" type="Method">DD6F4C2385CE48A18B71D2C70622F2B0</on_init_handler>
   <tooltip_template xml:lang="en">Show Part structure</tooltip_template>
   <name>EXT_mwt_Part_tgv_StructureBrowser</name>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_mwt_Part_tgv_WhereUsed.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_mwt_Part_tgv_WhereUsed.xml
@@ -1,0 +1,12 @@
+﻿<AML>
+ <Item type="CommandBarButton" id="145A4EA03BFA450684D17FB25450C60D" action="add">
+  <additional_data>{ "cui_disabled": "true" }</additional_data>
+  <image>../Images/ViewWorkflow.svg</image>
+  <include_events>SelectInToc,SelectInGrid</include_events>
+  <label xml:lang="en">Where Used</label>
+  <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">A34A513B4FBC475B862E33BD1311FECA</on_click_handler>
+  <on_init_handler keyed_name="EXT_TGV_Part_WhereUsed_Reinit" type="Method">E7CF60BF3D4D4652A25108404529297B</on_init_handler>
+  <tooltip_template xml:lang="en">Show where Part is used</tooltip_template>
+  <name>EXT_mwt_Part_tgv_WhereUsed</name>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_mwt_Part_tgv_WhereUsed.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_mwt_Part_tgv_WhereUsed.xml
@@ -4,7 +4,7 @@
   <image>../Images/ViewWorkflow.svg</image>
   <include_events>SelectInToc,SelectInGrid</include_events>
   <label xml:lang="en">Where Used</label>
-  <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">A34A513B4FBC475B862E33BD1311FECA</on_click_handler>
+  <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">DFCB4A7E712F44C7B894A69FDDFD2422</on_click_handler>
   <on_init_handler keyed_name="EXT_TGV_Part_WhereUsed_Reinit" type="Method">E7CF60BF3D4D4652A25108404529297B</on_init_handler>
   <tooltip_template xml:lang="en">Show where Part is used</tooltip_template>
   <name>EXT_mwt_Part_tgv_WhereUsed</name>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_twt_Part_tgv_StructureBrowser.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_twt_Part_tgv_StructureBrowser.xml
@@ -2,7 +2,7 @@
  <Item type="CommandBarButton" id="E1B94C59FF364B32B92CF1F531617D0F" action="add">
   <image>../Images/BlockInternal.svg</image>
   <label xml:lang="en">Structure Browser</label>
-  <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">195EB07305C247ACA7116CD3A03FD3E1</on_click_handler>
+  <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">072E8757D8674E4EB7BD27F04463472E</on_click_handler>
   <tooltip_template xml:lang="en">Show Part structure</tooltip_template>
   <name>EXT_twt_Part_tgv_StructureBrowser</name>
  </Item>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_twt_Part_tgv_StructureBrowser.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_twt_Part_tgv_StructureBrowser.xml
@@ -1,0 +1,9 @@
+﻿<AML>
+ <Item type="CommandBarButton" id="E1B94C59FF364B32B92CF1F531617D0F" action="add">
+  <image>../Images/BlockInternal.svg</image>
+  <label xml:lang="en">Structure Browser</label>
+  <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">195EB07305C247ACA7116CD3A03FD3E1</on_click_handler>
+  <tooltip_template xml:lang="en">Show Part structure</tooltip_template>
+  <name>EXT_twt_Part_tgv_StructureBrowser</name>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_twt_Part_tgv_WhereUsed.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_twt_Part_tgv_WhereUsed.xml
@@ -1,0 +1,9 @@
+﻿<AML>
+ <Item type="CommandBarButton" id="4760F298290C4E7885CD02FE490BB085" action="add">
+  <image>../Images/ViewWorkflow.svg</image>
+  <label xml:lang="en">Where Used</label>
+  <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">A34A513B4FBC475B862E33BD1311FECA</on_click_handler>
+  <tooltip_template xml:lang="en">Show where Part is used</tooltip_template>
+  <name>EXT_twt_Part_tgv_WhereUsed</name>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_twt_Part_tgv_WhereUsed.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarItem/EXT_twt_Part_tgv_WhereUsed.xml
@@ -2,7 +2,7 @@
  <Item type="CommandBarButton" id="4760F298290C4E7885CD02FE490BB085" action="add">
   <image>../Images/ViewWorkflow.svg</image>
   <label xml:lang="en">Where Used</label>
-  <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">A34A513B4FBC475B862E33BD1311FECA</on_click_handler>
+  <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">DFCB4A7E712F44C7B894A69FDDFD2422</on_click_handler>
   <tooltip_template xml:lang="en">Show where Part is used</tooltip_template>
   <name>EXT_twt_Part_tgv_WhereUsed</name>
  </Item>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSection/EXT_Part_MainWindowToolbar.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSection/EXT_Part_MainWindowToolbar.xml
@@ -1,0 +1,30 @@
+﻿<AML>
+ <Item type="CommandBarSection" id="A554D76F2C154CD39EA3D62F013E8048" action="add">
+  <classification>Data Model</classification>
+  <location_name>MainWindowToolbar</location_name>
+  <name>EXT_Part_MainWindowToolbar</name>
+  <Relationships>
+   <Item type="CommandBarSectionItem" id="018433EA79C646F88844146CFCC13DE1" action="add">
+    <action>Add</action>
+    <related_id keyed_name="EXT_mwt_Part_tgv_StructureBrowser" type="CommandBarItem">1217C91077AD4928B95F923C1B06660D</related_id>
+    <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+    <sort_order>620</sort_order>
+    <source_id keyed_name="EXT_Part_MainWindowToolbar" type="CommandBarSection">A554D76F2C154CD39EA3D62F013E8048</source_id>
+   </Item>
+   <Item type="CommandBarSectionItem" id="9364BF5FED76464AB92852671ECEC3E3" action="add">
+    <action>Add</action>
+    <related_id keyed_name="EXT_mwt_Part_tgv_WhereUsed" type="CommandBarItem">145A4EA03BFA450684D17FB25450C60D</related_id>
+    <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+    <sort_order>621</sort_order>
+    <source_id keyed_name="EXT_Part_MainWindowToolbar" type="CommandBarSection">A554D76F2C154CD39EA3D62F013E8048</source_id>
+   </Item>
+   <Item type="CommandBarSectionItem" id="E12952C95CE0450CA4C9D9085E0E372D" action="add">
+    <action>Add</action>
+    <related_id keyed_name="EXT_Part_tgv_Separator" type="CommandBarItem">63FBF765CBF54E2B829AFB394E1538DB</related_id>
+    <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+    <sort_order>623</sort_order>
+    <source_id keyed_name="EXT_Part_MainWindowToolbar" type="CommandBarSection">A554D76F2C154CD39EA3D62F013E8048</source_id>
+   </Item>
+  </Relationships>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSection/EXT_Part_Tearoff Window Toolbar.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSection/EXT_Part_Tearoff Window Toolbar.xml
@@ -1,0 +1,30 @@
+﻿<AML>
+ <Item type="CommandBarSection" id="31B2EAB1B78D4CDAB8A35AB0953A6D38" action="add">
+  <classification>Data Model</classification>
+  <location_name>TearoffWindowToolbar</location_name>
+  <name>EXT_Part_Tearoff Window Toolbar</name>
+  <Relationships>
+   <Item type="CommandBarSectionItem" id="9CACCE67069E4CA9B98F40106D8A4CFF" action="add">
+    <action>Add</action>
+    <related_id keyed_name="EXT_twt_Part_tgv_StructureBrowser" type="CommandBarItem">E1B94C59FF364B32B92CF1F531617D0F</related_id>
+    <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+    <sort_order>590</sort_order>
+    <source_id keyed_name="EXT_Part_Tearoff Window Toolbar" type="CommandBarSection">31B2EAB1B78D4CDAB8A35AB0953A6D38</source_id>
+   </Item>
+   <Item type="CommandBarSectionItem" id="2C97FE8735C34FD0B2848E5BD893310A" action="add">
+    <action>Add</action>
+    <related_id keyed_name="EXT_twt_Part_tgv_WhereUsed" type="CommandBarItem">4760F298290C4E7885CD02FE490BB085</related_id>
+    <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+    <sort_order>591</sort_order>
+    <source_id keyed_name="EXT_Part_Tearoff Window Toolbar" type="CommandBarSection">31B2EAB1B78D4CDAB8A35AB0953A6D38</source_id>
+   </Item>
+   <Item type="CommandBarSectionItem" id="8AFAA0B26E184D34B5E634D832B62E7C" action="add">
+    <action>Add</action>
+    <related_id keyed_name="EXT_Part_tgv_Separator" type="CommandBarItem">63FBF765CBF54E2B829AFB394E1538DB</related_id>
+    <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+    <sort_order>592</sort_order>
+    <source_id keyed_name="EXT_Part_Tearoff Window Toolbar" type="CommandBarSection">31B2EAB1B78D4CDAB8A35AB0953A6D38</source_id>
+   </Item>
+  </Relationships>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/018433EA79C646F88844146CFCC13DE1.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/018433EA79C646F88844146CFCC13DE1.xml
@@ -1,0 +1,20 @@
+﻿<AML>
+ <Item type="CommandBarSectionItem" id="018433EA79C646F88844146CFCC13DE1" action="add">
+  <action>Add</action>
+  <related_id keyed_name="EXT_mwt_Part_tgv_StructureBrowser" type="CommandBarItem">
+   <Item type="CommandBarButton" id="1217C91077AD4928B95F923C1B06660D" action="add">
+    <additional_data>{ "cui_disabled": "true" }</additional_data>
+    <image>../Images/BlockInternal.svg</image>
+    <include_events>SelectInToc,SelectInGrid</include_events>
+    <label xml:lang="en">Structure Browser</label>
+    <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">8F07B0EDF8DC481EB5CC1B837FBCE85F</on_click_handler>
+    <on_init_handler keyed_name="EXT_TGV_Part_BOMStructure_Reinit" type="Method">DD6F4C2385CE48A18B71D2C70622F2B0</on_init_handler>
+    <tooltip_template xml:lang="en">Show Part structure</tooltip_template>
+    <name>EXT_mwt_Part_tgv_StructureBrowser</name>
+   </Item>
+  </related_id>
+  <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+  <sort_order>620</sort_order>
+  <source_id keyed_name="EXT_Part_MainWindowToolbar" type="CommandBarSection">A554D76F2C154CD39EA3D62F013E8048</source_id>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/018433EA79C646F88844146CFCC13DE1.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/018433EA79C646F88844146CFCC13DE1.xml
@@ -7,7 +7,7 @@
     <image>../Images/BlockInternal.svg</image>
     <include_events>SelectInToc,SelectInGrid</include_events>
     <label xml:lang="en">Structure Browser</label>
-    <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">8F07B0EDF8DC481EB5CC1B837FBCE85F</on_click_handler>
+    <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">072E8757D8674E4EB7BD27F04463472E</on_click_handler>
     <on_init_handler keyed_name="EXT_TGV_Part_BOMStructure_Reinit" type="Method">DD6F4C2385CE48A18B71D2C70622F2B0</on_init_handler>
     <tooltip_template xml:lang="en">Show Part structure</tooltip_template>
     <name>EXT_mwt_Part_tgv_StructureBrowser</name>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/2C97FE8735C34FD0B2848E5BD893310A.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/2C97FE8735C34FD0B2848E5BD893310A.xml
@@ -5,7 +5,7 @@
    <Item type="CommandBarButton" id="4760F298290C4E7885CD02FE490BB085" action="add">
     <image>../Images/ViewWorkflow.svg</image>
     <label xml:lang="en">Where Used</label>
-    <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">6C475FCEAE22476AAD5185FE8BF47FB5</on_click_handler>
+    <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">DFCB4A7E712F44C7B894A69FDDFD2422</on_click_handler>
     <tooltip_template xml:lang="en">Show where Part is used</tooltip_template>
     <name>EXT_twt_Part_tgv_WhereUsed</name>
    </Item>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/2C97FE8735C34FD0B2848E5BD893310A.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/2C97FE8735C34FD0B2848E5BD893310A.xml
@@ -1,0 +1,17 @@
+﻿<AML>
+ <Item type="CommandBarSectionItem" id="2C97FE8735C34FD0B2848E5BD893310A" action="add">
+  <action>Add</action>
+  <related_id keyed_name="EXT_twt_Part_tgv_WhereUsed" type="CommandBarItem">
+   <Item type="CommandBarButton" id="4760F298290C4E7885CD02FE490BB085" action="add">
+    <image>../Images/ViewWorkflow.svg</image>
+    <label xml:lang="en">Where Used</label>
+    <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">6C475FCEAE22476AAD5185FE8BF47FB5</on_click_handler>
+    <tooltip_template xml:lang="en">Show where Part is used</tooltip_template>
+    <name>EXT_twt_Part_tgv_WhereUsed</name>
+   </Item>
+  </related_id>
+  <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+  <sort_order>591</sort_order>
+  <source_id keyed_name="EXT_Part_Tearoff Window Toolbar" type="CommandBarSection">31B2EAB1B78D4CDAB8A35AB0953A6D38</source_id>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/8AFAA0B26E184D34B5E634D832B62E7C.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/8AFAA0B26E184D34B5E634D832B62E7C.xml
@@ -1,0 +1,13 @@
+﻿<AML>
+ <Item type="CommandBarSectionItem" id="8AFAA0B26E184D34B5E634D832B62E7C" action="add">
+  <action>Add</action>
+  <related_id keyed_name="EXT_Part_tgv_Separator" type="CommandBarItem">
+   <Item type="CommandBarSeparator" id="63FBF765CBF54E2B829AFB394E1538DB" action="add">
+    <name>EXT_Part_tgv_Separator</name>
+   </Item>
+  </related_id>
+  <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+  <sort_order>592</sort_order>
+  <source_id keyed_name="EXT_Part_Tearoff Window Toolbar" type="CommandBarSection">31B2EAB1B78D4CDAB8A35AB0953A6D38</source_id>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/9364BF5FED76464AB92852671ECEC3E3.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/9364BF5FED76464AB92852671ECEC3E3.xml
@@ -7,7 +7,7 @@
     <image>../Images/ViewWorkflow.svg</image>
     <include_events>SelectInToc,SelectInGrid</include_events>
     <label xml:lang="en">Where Used</label>
-    <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">6C475FCEAE22476AAD5185FE8BF47FB5</on_click_handler>
+    <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">DFCB4A7E712F44C7B894A69FDDFD2422</on_click_handler>
     <on_init_handler keyed_name="EXT_TGV_Part_WhereUsed_Reinit" type="Method">E7CF60BF3D4D4652A25108404529297B</on_init_handler>
     <tooltip_template xml:lang="en">Show where Part is used</tooltip_template>
     <name>EXT_mwt_Part_tgv_WhereUsed</name>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/9364BF5FED76464AB92852671ECEC3E3.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/9364BF5FED76464AB92852671ECEC3E3.xml
@@ -1,0 +1,20 @@
+﻿<AML>
+ <Item type="CommandBarSectionItem" id="9364BF5FED76464AB92852671ECEC3E3" action="add">
+  <action>Add</action>
+  <related_id keyed_name="EXT_mwt_Part_tgv_WhereUsed" type="CommandBarItem">
+   <Item type="CommandBarButton" id="145A4EA03BFA450684D17FB25450C60D" action="add">
+    <additional_data>{ "cui_disabled": "true" }</additional_data>
+    <image>../Images/ViewWorkflow.svg</image>
+    <include_events>SelectInToc,SelectInGrid</include_events>
+    <label xml:lang="en">Where Used</label>
+    <on_click_handler keyed_name="EXT_TGV_Part_WhereUsed_onClick" type="Method">6C475FCEAE22476AAD5185FE8BF47FB5</on_click_handler>
+    <on_init_handler keyed_name="EXT_TGV_Part_WhereUsed_Reinit" type="Method">E7CF60BF3D4D4652A25108404529297B</on_init_handler>
+    <tooltip_template xml:lang="en">Show where Part is used</tooltip_template>
+    <name>EXT_mwt_Part_tgv_WhereUsed</name>
+   </Item>
+  </related_id>
+  <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+  <sort_order>621</sort_order>
+  <source_id keyed_name="EXT_Part_MainWindowToolbar" type="CommandBarSection">A554D76F2C154CD39EA3D62F013E8048</source_id>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/9CACCE67069E4CA9B98F40106D8A4CFF.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/9CACCE67069E4CA9B98F40106D8A4CFF.xml
@@ -5,7 +5,7 @@
    <Item type="CommandBarButton" id="E1B94C59FF364B32B92CF1F531617D0F" action="add">
     <image>../Images/BlockInternal.svg</image>
     <label xml:lang="en">Structure Browser</label>
-    <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">8F07B0EDF8DC481EB5CC1B837FBCE85F</on_click_handler>
+    <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">072E8757D8674E4EB7BD27F04463472E</on_click_handler>
     <tooltip_template xml:lang="en">Show Part structure</tooltip_template>
     <name>EXT_twt_Part_tgv_StructureBrowser</name>
    </Item>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/9CACCE67069E4CA9B98F40106D8A4CFF.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/9CACCE67069E4CA9B98F40106D8A4CFF.xml
@@ -1,0 +1,17 @@
+﻿<AML>
+ <Item type="CommandBarSectionItem" id="9CACCE67069E4CA9B98F40106D8A4CFF" action="add">
+  <action>Add</action>
+  <related_id keyed_name="EXT_twt_Part_tgv_StructureBrowser" type="CommandBarItem">
+   <Item type="CommandBarButton" id="E1B94C59FF364B32B92CF1F531617D0F" action="add">
+    <image>../Images/BlockInternal.svg</image>
+    <label xml:lang="en">Structure Browser</label>
+    <on_click_handler keyed_name="EXT_TGV_Part_BOMStructur_onClick" type="Method">8F07B0EDF8DC481EB5CC1B837FBCE85F</on_click_handler>
+    <tooltip_template xml:lang="en">Show Part structure</tooltip_template>
+    <name>EXT_twt_Part_tgv_StructureBrowser</name>
+   </Item>
+  </related_id>
+  <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+  <sort_order>590</sort_order>
+  <source_id keyed_name="EXT_Part_Tearoff Window Toolbar" type="CommandBarSection">31B2EAB1B78D4CDAB8A35AB0953A6D38</source_id>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/E12952C95CE0450CA4C9D9085E0E372D.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/CommandBarSectionItem/E12952C95CE0450CA4C9D9085E0E372D.xml
@@ -1,0 +1,13 @@
+﻿<AML>
+ <Item type="CommandBarSectionItem" id="E12952C95CE0450CA4C9D9085E0E372D" action="add">
+  <action>Add</action>
+  <related_id keyed_name="EXT_Part_tgv_Separator" type="CommandBarItem">
+   <Item type="CommandBarSeparator" id="63FBF765CBF54E2B829AFB394E1538DB" action="add">
+    <name>EXT_Part_tgv_Separator</name>
+   </Item>
+  </related_id>
+  <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+  <sort_order>623</sort_order>
+  <source_id keyed_name="EXT_Part_MainWindowToolbar" type="CommandBarSection">A554D76F2C154CD39EA3D62F013E8048</source_id>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/ITPresentationConfiguration/0286B85AA2AB4FEAB29C67D7B5A32132.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/ITPresentationConfiguration/0286B85AA2AB4FEAB29C67D7B5A32132.xml
@@ -1,0 +1,28 @@
+﻿<AML>
+ <Item type="ITPresentationConfiguration" id="0286B85AA2AB4FEAB29C67D7B5A32132" action="add">
+  <client>js</client>
+  <related_id keyed_name="EXT_part_presentation_configuration" type="PresentationConfiguration">
+   <Item type="PresentationConfiguration" id="AC5CEE829D1B48CA826163E11B54E104" action="add">
+    <secondary_icon>../Images/PartOff.svg</secondary_icon>
+    <style>background-color: rgba(137, 89, 171, 0.65);</style>
+    <name>EXT_part_presentation_configuration</name>
+    <Relationships>
+     <Item type="PresentationCommandBarSection" id="52A6147D7E07497784D1FAC13740F431" action="add">
+      <related_id keyed_name="EXT_Part_Tearoff Window Toolbar" type="CommandBarSection">31B2EAB1B78D4CDAB8A35AB0953A6D38</related_id>
+      <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="EXT_part_presentation_configuration" type="PresentationConfiguration">AC5CEE829D1B48CA826163E11B54E104</source_id>
+     </Item>
+     <Item type="PresentationCommandBarSection" id="15F838856D594F2AA4B29D6BD222B6E2" action="add">
+      <related_id keyed_name="EXT_Part_MainWindowToolbar" type="CommandBarSection">A554D76F2C154CD39EA3D62F013E8048</related_id>
+      <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+      <sort_order>200</sort_order>
+      <source_id keyed_name="EXT_part_presentation_configuration" type="PresentationConfiguration">AC5CEE829D1B48CA826163E11B54E104</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+  </related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="Part" type="ItemType" name="Part">4F1AC04A2B484F3ABA4E20DB63808A88</source_id>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_BOMStructur_onClick.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_BOMStructur_onClick.xml
@@ -1,5 +1,5 @@
 ﻿<AML>
- <Item type="Method" id="195EB07305C247ACA7116CD3A03FD3E1" action="add">
+ <Item type="Method" id="072E8757D8674E4EB7BD27F04463472E" action="add">
   <comments>onClick Method, called from CUI button</comments>
   <execution_allowed_to keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</execution_allowed_to>
   <method_code><![CDATA[var topWindow = aras.getMostTopWindowWithAras(window);

--- a/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_BOMStructur_onClick.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_BOMStructur_onClick.xml
@@ -1,0 +1,87 @@
+﻿<AML>
+ <Item type="Method" id="195EB07305C247ACA7116CD3A03FD3E1" action="add">
+  <comments>onClick Method, called from CUI button</comments>
+  <execution_allowed_to keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</execution_allowed_to>
+  <method_code><![CDATA[var topWindow = aras.getMostTopWindowWithAras(window);
+var tgvdIdParam;
+var startConditionProviderParam;
+var parametersProviderParam;
+
+tgvdIdParam = 'tgvdId=539401D569884D3383051AA26991F46B';
+
+var id;
+if (topWindow.work && topWindow.work.grid) 
+{ 
+    // get ID from grid
+    var workFrame = topWindow.work; 
+    // Optional: Add option to handle multible items at the same time
+    // var selectedIds = workFrame.grid.getSelectedItemIds(',').split(',');
+    id = workFrame.grid.getSelectedID();
+} else {
+    // get ID from Form
+    id = thisItem.getID();
+}
+
+/* Uncomment and customize the code below to customize startConditionProvider */
+
+topWindow.CustomStartConditionProvider = function(arg) {
+	this.getCondition = function() {
+	    var idlist = [id]; // ['ID1', 'ID2'];
+		var managerId = arg; //"Innovator Admin" ID comes from the startConditionProviderParam args
+		//id IN (idlist) AND managed_by_id = managerId
+		return {
+			'id': idlist
+		//	'managed_by_id': managerId
+		};
+	};
+};
+var managerIdentityId = 'DBA5D86402BF43D5976854B8B48FCDD1'; // "Innovator Admin" ID is for example
+var managerIdentityIdUriEncoded = encodeURIComponent(managerIdentityId);
+startConditionProviderParam = 'startConditionProvider=parent.CustomStartConditionProvider(' + managerIdentityIdUriEncoded + ')';
+
+
+/* Uncomment and modify the code below to customize parametersProvider */
+/*
+topWindow.CustomParametersProvider = function(arg) {
+	var parameters = {
+		'param1Name': 'param1Value',
+		'param2Name': arg //'param2Value' comes from the parametersProviderParam args
+	};
+
+	this.getParameters = function() {
+		return parameters;
+	};
+	this.setParameter = function(name, value) {
+		//for the case if a parameter is updated by enduser in TGV UI.
+		parameters[name] = value;
+	};
+}
+var param2ValueUriEncoded = encodeURIComponent('param2Value');
+parametersProviderParam = 'parametersProvider=parent.CustomParametersProvider(' + param2ValueUriEncoded + ')';
+*/
+
+// see more examples in Innovator\Client\Modules\aras.innovator.TreeGridView\Examples
+
+var tgvUrl = aras.getBaseURL('/Modules/aras.innovator.TreeGridView/Views/MainPage.html?');
+var allParams = [tgvdIdParam, startConditionProviderParam, parametersProviderParam];
+for (var i = 0; i < allParams.length; i++) {
+	if (allParams[i]) {
+		tgvUrl += (i === 0 ? '' : '&') + allParams[i];
+	}
+}
+
+var dialogParameters = {
+	dialogWidth: 1400,
+	dialogHeight: 600,
+	title: 'Structure Browser',
+	content: tgvUrl
+};
+
+topWindow.ArasModules.MaximazableDialog.show('iframe', dialogParameters).promise.then(function() {
+	delete topWindow.CustomStartConditionProvider;
+	delete topWindow.CustomParametersProvider;
+});]]></method_code>
+  <method_type>JavaScript</method_type>
+  <name>EXT_TGV_Part_BOMStructur_onClick</name>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_BOMStructure_Reinit.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_BOMStructure_Reinit.xml
@@ -1,0 +1,24 @@
+﻿<AML>
+ <Item type="Method" id="DD6F4C2385CE48A18B71D2C70622F2B0" action="add">
+  <comments>Init Method for custom 'EXT_Part_tgv_StructureBrowser' CUI element</comments>
+  <execution_allowed_to keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</execution_allowed_to>
+  <method_code><![CDATA[if (inArgs.isReinit) {
+	var topWindow = aras.getMostTopWindowWithAras(window);
+	var workerFrame = topWindow.work;
+	if (workerFrame.itemTypeName === 'InBasket Task') {
+		return {'cui_disabled': true};
+	}
+
+	if (workerFrame && workerFrame.grid) {
+		var itemIDs = workerFrame.grid.getSelectedItemIds();
+		var state = inArgs.eventState.isPromote && itemIDs && itemIDs.length == 1 && !isFunctionDisabled(workerFrame.itemTypeName, 'EXT_Part_tgv_StructureBrowser');
+		return {'cui_disabled': !state};
+	} else {
+		return {'cui_disabled': true};
+	}
+}
+return {};]]></method_code>
+  <method_type>JavaScript</method_type>
+  <name>EXT_TGV_Part_BOMStructure_Reinit</name>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_WhereUsed_Reinit.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_WhereUsed_Reinit.xml
@@ -1,0 +1,24 @@
+﻿<AML>
+ <Item type="Method" id="E7CF60BF3D4D4652A25108404529297B" action="add">
+  <comments>Init Method for custom 'EXT_Part_tgv_WhereUsed' CUI element</comments>
+  <execution_allowed_to keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</execution_allowed_to>
+  <method_code><![CDATA[if (inArgs.isReinit) {
+	var topWindow = aras.getMostTopWindowWithAras(window);
+	var workerFrame = topWindow.work;
+	if (workerFrame.itemTypeName === 'InBasket Task') {
+		return {'cui_disabled': true};
+	}
+	
+	if (workerFrame && workerFrame.grid) {
+		var itemIDs = workerFrame.grid.getSelectedItemIds();
+		var state = inArgs.eventState.isPromote && itemIDs && itemIDs.length == 1 && !isFunctionDisabled(workerFrame.itemTypeName, 'EXT_Part_tgv_WhereUsed');
+		return {'cui_disabled': !state};
+	} else {
+		return {'cui_disabled': true};
+	}
+}
+return {};]]></method_code>
+  <method_type>JavaScript</method_type>
+  <name>EXT_TGV_Part_WhereUsed_Reinit</name>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_WhereUsed_onClick.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_WhereUsed_onClick.xml
@@ -1,5 +1,5 @@
 ﻿<AML>
- <Item type="Method" id="A34A513B4FBC475B862E33BD1311FECA" action="add">
+ <Item type="Method" id="DFCB4A7E712F44C7B894A69FDDFD2422" action="add">
   <comments>onClick Method, called from CUI button</comments>
   <execution_allowed_to keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</execution_allowed_to>
   <method_code><![CDATA[var topWindow = aras.getMostTopWindowWithAras(window);
@@ -79,8 +79,7 @@ var dialogParameters = {
 topWindow.ArasModules.MaximazableDialog.show('iframe', dialogParameters).promise.then(function() {
 	delete topWindow.CustomStartConditionProvider;
 	delete topWindow.CustomParametersProvider;
-});
-]]></method_code>
+});]]></method_code>
   <method_type>JavaScript</method_type>
   <name>EXT_TGV_Part_WhereUsed_onClick</name>
  </Item>

--- a/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_WhereUsed_onClick.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/Method/EXT_TGV_Part_WhereUsed_onClick.xml
@@ -1,0 +1,87 @@
+﻿<AML>
+ <Item type="Method" id="A34A513B4FBC475B862E33BD1311FECA" action="add">
+  <comments>onClick Method, called from CUI button</comments>
+  <execution_allowed_to keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</execution_allowed_to>
+  <method_code><![CDATA[var topWindow = aras.getMostTopWindowWithAras(window);
+var tgvdIdParam;
+var startConditionProviderParam;
+var parametersProviderParam;
+
+tgvdIdParam = 'tgvdId=4537BD062A1548F79F22C2E8BD7BB170';
+
+var id;
+if (topWindow.work && topWindow.work.grid) 
+{ 
+    // get ID from grid
+    var workFrame = topWindow.work; 
+    // Optional: Add option to handle multible items at the same time
+    // var selectedIds = workFrame.grid.getSelectedItemIds(',').split(',');
+    id = workFrame.grid.getSelectedID();
+} else {
+    // get ID from Form
+    id = thisItem.getID();
+}
+
+/* Uncomment and customize the code below to customize startConditionProvider */
+topWindow.CustomStartConditionProvider = function(arg) {
+	this.getCondition = function() {
+	    var idlist = [id]; // ['ID1', 'ID2'];
+		var managerId = arg; //"Innovator Admin" ID comes from the startConditionProviderParam args
+		//id IN (idlist) AND managed_by_id = managerId
+		return {
+			'id': idlist,
+			//'managed_by_id': managerId
+		};
+	};
+};
+var managerIdentityId = 'DBA5D86402BF43D5976854B8B48FCDD1'; // "Innovator Admin" ID is for example
+var managerIdentityIdUriEncoded = encodeURIComponent(managerIdentityId);
+startConditionProviderParam = 'startConditionProvider=parent.CustomStartConditionProvider(' + managerIdentityIdUriEncoded + ')';
+
+
+/* Uncomment and modify the code below to customize parametersProvider */
+/*
+topWindow.CustomParametersProvider = function(arg) {
+	var parameters = {
+		'param1Name': 'param1Value',
+		'param2Name': arg //'param2Value' comes from the parametersProviderParam args
+	};
+
+	this.getParameters = function() {
+		return parameters;
+	};
+	this.setParameter = function(name, value) {
+		//for the case if a parameter is updated by enduser in TGV UI.
+		parameters[name] = value;
+	};
+}
+var param2ValueUriEncoded = encodeURIComponent('param2Value');
+parametersProviderParam = 'parametersProvider=parent.CustomParametersProvider(' + param2ValueUriEncoded + ')';
+*/
+
+// see more examples in Innovator\Client\Modules\aras.innovator.TreeGridView\Examples
+
+var tgvUrl = aras.getBaseURL('/Modules/aras.innovator.TreeGridView/Views/MainPage.html?');
+var allParams = [tgvdIdParam, startConditionProviderParam, parametersProviderParam];
+for (var i = 0; i < allParams.length; i++) {
+	if (allParams[i]) {
+		tgvUrl += (i === 0 ? '' : '&') + allParams[i];
+	}
+}
+
+var dialogParameters = {
+	dialogWidth: 1400,
+	dialogHeight: 600,
+	title: 'Where Used',
+	content: tgvUrl
+};
+
+topWindow.ArasModules.MaximazableDialog.show('iframe', dialogParameters).promise.then(function() {
+	delete topWindow.CustomStartConditionProvider;
+	delete topWindow.CustomParametersProvider;
+});
+]]></method_code>
+  <method_type>JavaScript</method_type>
+  <name>EXT_TGV_Part_WhereUsed_onClick</name>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/PresentationConfiguration/EXT_part_presentation_configuration.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/PresentationConfiguration/EXT_part_presentation_configuration.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="PresentationConfiguration" id="AC5CEE829D1B48CA826163E11B54E104" action="add">
+  <secondary_icon>../Images/PartOff.svg</secondary_icon>
+  <style>background-color: rgba(137, 89, 171, 0.65);</style>
+  <name>EXT_part_presentation_configuration</name>
+  <Relationships>
+   <Item type="PresentationCommandBarSection" id="52A6147D7E07497784D1FAC13740F431" action="add">
+    <related_id keyed_name="EXT_Part_Tearoff Window Toolbar" type="CommandBarSection">31B2EAB1B78D4CDAB8A35AB0953A6D38</related_id>
+    <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="EXT_part_presentation_configuration" type="PresentationConfiguration">AC5CEE829D1B48CA826163E11B54E104</source_id>
+   </Item>
+   <Item type="PresentationCommandBarSection" id="15F838856D594F2AA4B29D6BD222B6E2" action="add">
+    <related_id keyed_name="EXT_Part_MainWindowToolbar" type="CommandBarSection">A554D76F2C154CD39EA3D62F013E8048</related_id>
+    <role keyed_name="World" type="Identity">A73B655731924CD0B027E4F4D5FCC0A9</role>
+    <sort_order>200</sort_order>
+    <source_id keyed_name="EXT_part_presentation_configuration" type="PresentationConfiguration">AC5CEE829D1B48CA826163E11B54E104</source_id>
+   </Item>
+  </Relationships>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/qry_QueryDefinition/EXT_Part_BOMStructure.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/qry_QueryDefinition/EXT_Part_BOMStructure.xml
@@ -1,0 +1,245 @@
+﻿<AML>
+ <Item type="qry_QueryDefinition" id="A886F4A7966240A2A1D431F2F19480DB" action="add">
+  <description>Replacement of the previous BOM Structure tab in ItemType Part</description>
+  <name>EXT_Part_BOMStructure</name>
+  <Relationships>
+   <Item type="qry_QueryItem" id="6E6AEFEF328C43ADB4F12D647DAAFBB6" action="add">
+    <alias>Part</alias>
+    <filter_xml />
+    <item_type keyed_name="Part" type="ItemType" name="Part">4F1AC04A2B484F3ABA4E20DB63808A88</item_type>
+    <ref_id>1A03431C6BB3412DA6CC8EC9652C3EEF</ref_id>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="3F323811EB154921A94CE7C768BBC475" action="add">
+      <property_name>item_number</property_name>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="6E6AEFEF328C43ADB4F12D647DAAFBB6" type="qry_QueryItem">6E6AEFEF328C43ADB4F12D647DAAFBB6</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="C9C4BDFD94BE4B4FB8FF93C0A898D20E" action="add">
+      <property_name>name</property_name>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="6E6AEFEF328C43ADB4F12D647DAAFBB6" type="qry_QueryItem">6E6AEFEF328C43ADB4F12D647DAAFBB6</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="4D06DC93E17B4602A956204A5C69CC49" action="add">
+      <property_name>id</property_name>
+      <sort_order>640</sort_order>
+      <source_id keyed_name="6E6AEFEF328C43ADB4F12D647DAAFBB6" type="qry_QueryItem">6E6AEFEF328C43ADB4F12D647DAAFBB6</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="0CD23E4023D949C5A5C93136E25B91F8" action="add">
+      <property_name>generation</property_name>
+      <sort_order>1024</sort_order>
+      <source_id keyed_name="6E6AEFEF328C43ADB4F12D647DAAFBB6" type="qry_QueryItem">6E6AEFEF328C43ADB4F12D647DAAFBB6</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="60358B4977BB4971B16187E744810D3A" action="add">
+      <property_name>state</property_name>
+      <sort_order>1152</sort_order>
+      <source_id keyed_name="6E6AEFEF328C43ADB4F12D647DAAFBB6" type="qry_QueryItem">6E6AEFEF328C43ADB4F12D647DAAFBB6</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="EB78721389ED4DE4B4466C72E7B8D239" action="add">
+      <property_name>keyed_name</property_name>
+      <sort_order>1408</sort_order>
+      <source_id keyed_name="6E6AEFEF328C43ADB4F12D647DAAFBB6" type="qry_QueryItem">6E6AEFEF328C43ADB4F12D647DAAFBB6</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="69A5C6C12BFA4A248FD55957166B734F" action="add">
+      <property_name>unit</property_name>
+      <sort_order>1536</sort_order>
+      <source_id keyed_name="6E6AEFEF328C43ADB4F12D647DAAFBB6" type="qry_QueryItem">6E6AEFEF328C43ADB4F12D647DAAFBB6</source_id>
+     </Item>
+     <Item type="qry_QueryItemSortProperty" id="F81BCA1A781C464CADC34C57F4109B6C" action="add">
+      <property_name>item_number</property_name>
+      <sort_order>128</sort_order>
+      <sort_order_direction>asc</sort_order_direction>
+      <source_id keyed_name="6E6AEFEF328C43ADB4F12D647DAAFBB6" type="qry_QueryItem">6E6AEFEF328C43ADB4F12D647DAAFBB6</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryItem" id="74AB159100C0476CABFFDC878F502968" action="add">
+    <alias>Part BOM</alias>
+    <item_type keyed_name="Part BOM" type="ItemType" name="Part BOM">5E9C5A12CC58413A8670CF4003C57848</item_type>
+    <ref_id>994020266FEB4B2EB5D94238AAC97E6D</ref_id>
+    <sort_order>256</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="EAF899B8FAAC4A379B977B36B8AB1D8E" action="add">
+      <property_name>quantity</property_name>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="74AB159100C0476CABFFDC878F502968" type="qry_QueryItem">74AB159100C0476CABFFDC878F502968</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="3B14C50E6AC8434987727C6FAEC0A5EA" action="add">
+      <property_name>sort_order</property_name>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="74AB159100C0476CABFFDC878F502968" type="qry_QueryItem">74AB159100C0476CABFFDC878F502968</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryItem" id="97B84E73DC914877A054E75204C0FC9D" action="add">
+    <alias>Part AML</alias>
+    <item_type keyed_name="Part AML" type="ItemType" name="Part AML">332F11B553BA4CCC892201C1FA51F056</item_type>
+    <ref_id>02F1D61FBF964AD48EE48AC23B1C29DF</ref_id>
+    <sort_order>384</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+   </Item>
+   <Item type="qry_QueryItem" id="E5FC538FB75B4523AAD704494C2D0858" action="add">
+    <alias>Manufacturer Part</alias>
+    <item_type keyed_name="Manufacturer Part" type="ItemType" name="Manufacturer Part">FDE9DA6F52C642EA807287C340EE0B72</item_type>
+    <ref_id>BE33AE7715CD4702BB2DA1B4C05D29F2</ref_id>
+    <sort_order>512</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="D3C4E463487043199058D1E71B40498E" action="add">
+      <property_name>item_number</property_name>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="E5FC538FB75B4523AAD704494C2D0858" type="qry_QueryItem">E5FC538FB75B4523AAD704494C2D0858</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="25F241D51D614FDEAD71A953F9EFF5CD" action="add">
+      <property_name>manufacturer</property_name>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="E5FC538FB75B4523AAD704494C2D0858" type="qry_QueryItem">E5FC538FB75B4523AAD704494C2D0858</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="D7905B5819714E838BB23E804983A90A" action="add">
+      <property_name>id</property_name>
+      <sort_order>384</sort_order>
+      <source_id keyed_name="E5FC538FB75B4523AAD704494C2D0858" type="qry_QueryItem">E5FC538FB75B4523AAD704494C2D0858</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryItem" id="49C72ACCA06F46C18220B476AF66E783" action="add">
+    <alias>Manufacturer Part File</alias>
+    <item_type keyed_name="Manufacturer Part File" type="ItemType" name="Manufacturer Part File">40E21F80C9D34E86BADA03D47D4D6B39</item_type>
+    <ref_id>67C0D10B8C1244C4BF9E8EAACEEDD25F</ref_id>
+    <sort_order>768</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="1037CEE917874314A4BAB5D29218429B" action="add">
+      <property_name>related_id</property_name>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="49C72ACCA06F46C18220B476AF66E783" type="qry_QueryItem">49C72ACCA06F46C18220B476AF66E783</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryItem" id="EDCDFD21AF5D4D52A8CDEA8CBA904D9D" action="add">
+    <alias>Part Document</alias>
+    <item_type keyed_name="Part Document" type="ItemType" name="Part Document">BFE7AD9711A547FBB05827B5169493CE</item_type>
+    <ref_id>87D7DD48EDDF44B4A5B0880F77F297E5</ref_id>
+    <sort_order>896</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+   </Item>
+   <Item type="qry_QueryItem" id="6F0371558CD54D92B259A78AF35520E6" action="add">
+    <alias>Document</alias>
+    <item_type keyed_name="Document" type="ItemType" name="Document">B88C14B99EF449828C5D926E39EE8B89</item_type>
+    <ref_id>B777A2C9252B4AC69C6916F8AE986845</ref_id>
+    <sort_order>1024</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="CC6525689803436CB3B11BEB0D454C32" action="add">
+      <property_name>item_number</property_name>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="6F0371558CD54D92B259A78AF35520E6" type="qry_QueryItem">6F0371558CD54D92B259A78AF35520E6</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="654421CBC35D4682A80D5F5DDC3EFD7E" action="add">
+      <property_name>id</property_name>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="6F0371558CD54D92B259A78AF35520E6" type="qry_QueryItem">6F0371558CD54D92B259A78AF35520E6</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryReference" id="A5E154B229EA456E8216E55257ABAC44" action="add">
+    <child_ref_id>1A03431C6BB3412DA6CC8EC9652C3EEF</child_ref_id>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="CD9C029552E94512991EA8D522F6E700" action="add">
+    <child_ref_id>994020266FEB4B2EB5D94238AAC97E6D</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="source_id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>1A03431C6BB3412DA6CC8EC9652C3EEF</parent_ref_id>
+    <ref_id>82C6D3682888425E823EF5F153516D4A</ref_id>
+    <sort_order>256</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="A0A67CBAF251437D8D98221E24A1AE5D" action="add">
+    <child_ref_id>1A03431C6BB3412DA6CC8EC9652C3EEF</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="related_id" />
+		<property name="id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>994020266FEB4B2EB5D94238AAC97E6D</parent_ref_id>
+    <ref_id>E3FC4AAF0257421A90F2E299A37871E3</ref_id>
+    <sort_order>384</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="046E7607C4AF40898D85F98EE36206E8" action="add">
+    <child_ref_id>02F1D61FBF964AD48EE48AC23B1C29DF</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="source_id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>1A03431C6BB3412DA6CC8EC9652C3EEF</parent_ref_id>
+    <ref_id>003C5D32C3404FA5B3ED2442D60AA0C5</ref_id>
+    <sort_order>512</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="64B07FF4B4654732ADF574F32D2BFE58" action="add">
+    <child_ref_id>BE33AE7715CD4702BB2DA1B4C05D29F2</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="related_id" />
+		<property name="id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>02F1D61FBF964AD48EE48AC23B1C29DF</parent_ref_id>
+    <ref_id>8ACE51D6941E48BC89662A0F7D209E87</ref_id>
+    <sort_order>640</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="E989A154B79C412A91A6DE7F4D4A4604" action="add">
+    <child_ref_id>67C0D10B8C1244C4BF9E8EAACEEDD25F</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="source_id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>BE33AE7715CD4702BB2DA1B4C05D29F2</parent_ref_id>
+    <ref_id>0946DDEF94DD4CD7857BB5657D11D0B4</ref_id>
+    <sort_order>896</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="8D9D0F6320E4458E8EB102D90AFC0097" action="add">
+    <child_ref_id>87D7DD48EDDF44B4A5B0880F77F297E5</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="source_id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>1A03431C6BB3412DA6CC8EC9652C3EEF</parent_ref_id>
+    <ref_id>5C010340FC09431788D4E9CE595DB917</ref_id>
+    <sort_order>1024</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="AEF4C63F90B04BF38F28CE7EAF49EBA2" action="add">
+    <child_ref_id>B777A2C9252B4AC69C6916F8AE986845</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="related_id" />
+		<property name="id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>87D7DD48EDDF44B4A5B0880F77F297E5</parent_ref_id>
+    <ref_id>115B9001F57344A2814BDF881BF1A0F1</ref_id>
+    <sort_order>1152</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</source_id>
+   </Item>
+  </Relationships>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/qry_QueryDefinition/EXT_Part_WhereUsed.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/qry_QueryDefinition/EXT_Part_WhereUsed.xml
@@ -1,0 +1,428 @@
+﻿<AML>
+ <Item type="qry_QueryDefinition" id="75DD65121EDE498F88FF7129720F3AA9" action="add">
+  <name>EXT_Part_WhereUsed</name>
+  <Relationships>
+   <Item type="qry_QueryItem" id="8DBC1991F2D04279A31BBCAA2AFABF7F" action="add">
+    <alias>Part</alias>
+    <item_type keyed_name="Part" type="ItemType" name="Part">4F1AC04A2B484F3ABA4E20DB63808A88</item_type>
+    <ref_id>929CBE2034254E3A83BB391A667F3382</ref_id>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="A0E0924CD694492B9E445F4BCB78C41D" action="add">
+      <property_name>item_number</property_name>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="8DBC1991F2D04279A31BBCAA2AFABF7F" type="qry_QueryItem">8DBC1991F2D04279A31BBCAA2AFABF7F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="1E02F2AF882F444F93065F3A52C29E9C" action="add">
+      <property_name>major_rev</property_name>
+      <sort_order>768</sort_order>
+      <source_id keyed_name="8DBC1991F2D04279A31BBCAA2AFABF7F" type="qry_QueryItem">8DBC1991F2D04279A31BBCAA2AFABF7F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="D28E2C72ED7447A69B4BC4920D51F773" action="add">
+      <property_name>minor_rev</property_name>
+      <sort_order>896</sort_order>
+      <source_id keyed_name="8DBC1991F2D04279A31BBCAA2AFABF7F" type="qry_QueryItem">8DBC1991F2D04279A31BBCAA2AFABF7F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="16F35D3F351A43CC94CA1E901F30D924" action="add">
+      <property_name>generation</property_name>
+      <sort_order>1024</sort_order>
+      <source_id keyed_name="8DBC1991F2D04279A31BBCAA2AFABF7F" type="qry_QueryItem">8DBC1991F2D04279A31BBCAA2AFABF7F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="8F1440D3F75F46CD97A466D0EA0365CA" action="add">
+      <property_name>unit</property_name>
+      <sort_order>1152</sort_order>
+      <source_id keyed_name="8DBC1991F2D04279A31BBCAA2AFABF7F" type="qry_QueryItem">8DBC1991F2D04279A31BBCAA2AFABF7F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="949686038E3E4C0DB7384AA6F7A5FEA8" action="add">
+      <property_name>state</property_name>
+      <sort_order>1408</sort_order>
+      <source_id keyed_name="8DBC1991F2D04279A31BBCAA2AFABF7F" type="qry_QueryItem">8DBC1991F2D04279A31BBCAA2AFABF7F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="04DAFE8B7A96437B9E8A2C18548B977C" action="add">
+      <property_name>id</property_name>
+      <sort_order>1664</sort_order>
+      <source_id keyed_name="8DBC1991F2D04279A31BBCAA2AFABF7F" type="qry_QueryItem">8DBC1991F2D04279A31BBCAA2AFABF7F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="3A034795BDAF480DB486A7514522EF50" action="add">
+      <property_name>name</property_name>
+      <sort_order>1792</sort_order>
+      <source_id keyed_name="8DBC1991F2D04279A31BBCAA2AFABF7F" type="qry_QueryItem">8DBC1991F2D04279A31BBCAA2AFABF7F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSortProperty" id="117A1697C25F492DB7FD96ED8C955A49" action="add">
+      <property_name>item_number</property_name>
+      <sort_order>128</sort_order>
+      <sort_order_direction>desc</sort_order_direction>
+      <source_id keyed_name="8DBC1991F2D04279A31BBCAA2AFABF7F" type="qry_QueryItem">8DBC1991F2D04279A31BBCAA2AFABF7F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSortProperty" id="64CC85BE1EFC4145AD7A03AFB8C3EC1E" action="add">
+      <property_name>generation</property_name>
+      <sort_order>256</sort_order>
+      <sort_order_direction>desc</sort_order_direction>
+      <source_id keyed_name="8DBC1991F2D04279A31BBCAA2AFABF7F" type="qry_QueryItem">8DBC1991F2D04279A31BBCAA2AFABF7F</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryItem" id="59614AACB2B144CBA9D911D7F1FEAE2F" action="add">
+    <alias>Part BOM related_id</alias>
+    <item_type keyed_name="Part BOM" type="ItemType" name="Part BOM">5E9C5A12CC58413A8670CF4003C57848</item_type>
+    <ref_id>91F8A554B1EA497FB556A07FB7D4B43C</ref_id>
+    <sort_order>256</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="B61D519D49884ADA87042B95FA747E30" action="add">
+      <property_name>quantity</property_name>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="59614AACB2B144CBA9D911D7F1FEAE2F" type="qry_QueryItem">59614AACB2B144CBA9D911D7F1FEAE2F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="B3F1A5564C2D44F3881B116DEF011DF3" action="add">
+      <property_name>sort_order</property_name>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="59614AACB2B144CBA9D911D7F1FEAE2F" type="qry_QueryItem">59614AACB2B144CBA9D911D7F1FEAE2F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="80A6B08818BD4F93A358A4410933CA5F" action="add">
+      <property_name>reference_designator</property_name>
+      <sort_order>384</sort_order>
+      <source_id keyed_name="59614AACB2B144CBA9D911D7F1FEAE2F" type="qry_QueryItem">59614AACB2B144CBA9D911D7F1FEAE2F</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="5582F0A05C4348108945C235C9668C56" action="add">
+      <property_name>keyed_name</property_name>
+      <sort_order>512</sort_order>
+      <source_id keyed_name="59614AACB2B144CBA9D911D7F1FEAE2F" type="qry_QueryItem">59614AACB2B144CBA9D911D7F1FEAE2F</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryItem" id="ECA3C093453C4094BBE98F4D2319D494" action="add">
+    <alias>mpp_ProcessPlan</alias>
+    <item_type keyed_name="mpp_ProcessPlanProducedPart" type="ItemType" name="mpp_ProcessPlanProducedPart">231BE11042F44C1C9B3EFD38FAF1CC36</item_type>
+    <ref_id>3E2414194D5E4BD3BEF58879E7BBA459</ref_id>
+    <sort_order>384</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryItem" id="C2653EA8EB784E879615372E9585188D" action="add">
+    <alias>Simple MCO Part related_id</alias>
+    <item_type keyed_name="Simple MCO Part" type="ItemType" name="Simple MCO Part">9CFBE6B6338B4A2895FC371792BE53B8</item_type>
+    <ref_id>AE893D13EFCF4F269AB75D5413BE4E3C</ref_id>
+    <sort_order>512</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryItem" id="F18F2989D8B440C583B1C90248B48479" action="add">
+    <alias>Change Controlled Item</alias>
+    <item_type keyed_name="Change Controlled Item" type="ItemType" name="Change Controlled Item">198BF0BCCC364EE29F56434D803D5F1E</item_type>
+    <ref_id>C904BD5E210F4CAE84F2FED426AA6A74</ref_id>
+    <sort_order>896</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="CAC1250B8E96437D8E1E1D26F7706AED" action="add">
+      <property_name>id</property_name>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="F18F2989D8B440C583B1C90248B48479" type="qry_QueryItem">F18F2989D8B440C583B1C90248B48479</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryItem" id="4F73D865298646F6A603F6AC622FACB8" action="add">
+    <alias>mpp_ProcessPlan_1</alias>
+    <item_type keyed_name="mpp_ProcessPlan" type="ItemType" name="mpp_ProcessPlan">4E030A4723224002B3E94F40F01AC1DE</item_type>
+    <ref_id>766DBE4DCA0F46A1B74BB03D5DFDCF8D</ref_id>
+    <sort_order>1280</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="8DAC0C70A78745439B515D8400972E97" action="add">
+      <property_name>name</property_name>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="4F73D865298646F6A603F6AC622FACB8" type="qry_QueryItem">4F73D865298646F6A603F6AC622FACB8</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="40AA4DE67FA14E4EA289A75E77CEE165" action="add">
+      <property_name>state</property_name>
+      <sort_order>384</sort_order>
+      <source_id keyed_name="4F73D865298646F6A603F6AC622FACB8" type="qry_QueryItem">4F73D865298646F6A603F6AC622FACB8</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="8B3FF5BE2CE7406E8299E3865A435E07" action="add">
+      <property_name>id</property_name>
+      <sort_order>512</sort_order>
+      <source_id keyed_name="4F73D865298646F6A603F6AC622FACB8" type="qry_QueryItem">4F73D865298646F6A603F6AC622FACB8</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryItem" id="A8700999C45D4328B54D91C94E04C06E" action="add">
+    <alias>Simple MCO</alias>
+    <item_type keyed_name="Simple MCO" type="ItemType" name="Simple MCO">2826F2403689438295EDBF60BEAE7C74</item_type>
+    <ref_id>9C09DFE83A9E49DE84EB360C81650235</ref_id>
+    <sort_order>1408</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="F51F2BF9477842969478CF32E753F30E" action="add">
+      <property_name>item_number</property_name>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="A8700999C45D4328B54D91C94E04C06E" type="qry_QueryItem">A8700999C45D4328B54D91C94E04C06E</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="373AB52F1A26489597AA7A9C6BD48BC0" action="add">
+      <property_name>id</property_name>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="A8700999C45D4328B54D91C94E04C06E" type="qry_QueryItem">A8700999C45D4328B54D91C94E04C06E</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="6DCB2070D1A146E6A013CF06E0A966A4" action="add">
+      <property_name>title</property_name>
+      <sort_order>384</sort_order>
+      <source_id keyed_name="A8700999C45D4328B54D91C94E04C06E" type="qry_QueryItem">A8700999C45D4328B54D91C94E04C06E</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="DE4BD9DD658E4C229B55A08F6B087F3B" action="add">
+      <property_name>state</property_name>
+      <sort_order>512</sort_order>
+      <source_id keyed_name="A8700999C45D4328B54D91C94E04C06E" type="qry_QueryItem">A8700999C45D4328B54D91C94E04C06E</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryItem" id="66331050CB3F4129BA24EFF4E3895ED1" action="add">
+    <alias>Affected Item affected_id</alias>
+    <item_type keyed_name="Affected Item" type="ItemType" name="Affected Item">BFAAB0F6838D4F80BF12CB328FF5B097</item_type>
+    <ref_id>877BBFDA8984409C975D6076D089F0D8</ref_id>
+    <sort_order>1536</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryItem" id="075F75847B7E4C54ADA290E098B321CE" action="add">
+    <alias>Affected Item new_item_id</alias>
+    <item_type keyed_name="Affected Item" type="ItemType" name="Affected Item">BFAAB0F6838D4F80BF12CB328FF5B097</item_type>
+    <ref_id>819FB380465D44119C3BEC1E36E5F355</ref_id>
+    <sort_order>1664</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryItem" id="0FA48172DF6243A8A9CD5975B4AAFDE2" action="add">
+    <alias>Express ECO AffItem related_id</alias>
+    <item_type keyed_name="Express ECO Affected Item" type="ItemType" name="Express ECO Affected Item">FFE118760ADB44FC984FBE0B633414FC</item_type>
+    <ref_id>AB3113CFDF694029BE9217B52D4AF669</ref_id>
+    <sort_order>1792</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryItem" id="698D386EC60B4ED9BAC0947F0869A9D9" action="add">
+    <alias>Express ECO AffItem related_id_1</alias>
+    <item_type keyed_name="Express ECO Affected Item" type="ItemType" name="Express ECO Affected Item">FFE118760ADB44FC984FBE0B633414FC</item_type>
+    <ref_id>3488D8378E1B4187A43FAF41C43AD366</ref_id>
+    <sort_order>1920</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryItem" id="761012F0F62843B1BB01E1DF96ACEB5B" action="add">
+    <alias>Express ECO</alias>
+    <item_type keyed_name="Express ECO" type="ItemType" name="Express ECO">CBA93BEFFB4F499CAF122CB79E204983</item_type>
+    <ref_id>89FA3907EB824F04A73DDDD72D824E4A</ref_id>
+    <sort_order>2048</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="0CD28F6FCCD94CC89FAD4FB04EB567DD" action="add">
+      <property_name>id</property_name>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="761012F0F62843B1BB01E1DF96ACEB5B" type="qry_QueryItem">761012F0F62843B1BB01E1DF96ACEB5B</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="C66E3B688E344840A8299670620330EE" action="add">
+      <property_name>state</property_name>
+      <sort_order>384</sort_order>
+      <source_id keyed_name="761012F0F62843B1BB01E1DF96ACEB5B" type="qry_QueryItem">761012F0F62843B1BB01E1DF96ACEB5B</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="9C71B981A023436FB288A1BC2403D5E6" action="add">
+      <property_name>title</property_name>
+      <sort_order>512</sort_order>
+      <source_id keyed_name="761012F0F62843B1BB01E1DF96ACEB5B" type="qry_QueryItem">761012F0F62843B1BB01E1DF96ACEB5B</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryItem" id="BC2AB2D900E8493A9B855AD6CE38E2C2" action="add">
+    <alias>Express ECO_1</alias>
+    <item_type keyed_name="Express ECO" type="ItemType" name="Express ECO">CBA93BEFFB4F499CAF122CB79E204983</item_type>
+    <ref_id>0E2BD3FC472C45309F11D10C1E998169</ref_id>
+    <sort_order>2176</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+    <Relationships>
+     <Item type="qry_QueryItemSelectProperty" id="C8FA293E577A4BC1A9DAA2E3562E9742" action="add">
+      <property_name>id</property_name>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="BC2AB2D900E8493A9B855AD6CE38E2C2" type="qry_QueryItem">BC2AB2D900E8493A9B855AD6CE38E2C2</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="465776E42A18457ABD9CFE08379AFFD5" action="add">
+      <property_name>state</property_name>
+      <sort_order>384</sort_order>
+      <source_id keyed_name="BC2AB2D900E8493A9B855AD6CE38E2C2" type="qry_QueryItem">BC2AB2D900E8493A9B855AD6CE38E2C2</source_id>
+     </Item>
+     <Item type="qry_QueryItemSelectProperty" id="6965EDD84AA940F0BD93F3F14C4986C4" action="add">
+      <property_name>title</property_name>
+      <sort_order>512</sort_order>
+      <source_id keyed_name="BC2AB2D900E8493A9B855AD6CE38E2C2" type="qry_QueryItem">BC2AB2D900E8493A9B855AD6CE38E2C2</source_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="qry_QueryReference" id="88AA130772AC40BD841FC70A3EA583F5" action="add">
+    <child_ref_id>929CBE2034254E3A83BB391A667F3382</child_ref_id>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="B79BCCB5F5E7420BB51AF376C10EB275" action="add">
+    <child_ref_id>91F8A554B1EA497FB556A07FB7D4B43C</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="related_id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>929CBE2034254E3A83BB391A667F3382</parent_ref_id>
+    <ref_id>5682EB9B0A4B436DBBF9FBB845D6D615</ref_id>
+    <sort_order>256</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="DE0BCB8DB84F49879A7973609FCB6F80" action="add">
+    <child_ref_id>929CBE2034254E3A83BB391A667F3382</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="source_id" />
+		<property name="id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>91F8A554B1EA497FB556A07FB7D4B43C</parent_ref_id>
+    <ref_id>84D820BBCEDF452EB8FC24AF38EA735F</ref_id>
+    <sort_order>384</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="C1796D1F20BA494D92C1F9BCA3EB488A" action="add">
+    <child_ref_id>3E2414194D5E4BD3BEF58879E7BBA459</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="related_id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>929CBE2034254E3A83BB391A667F3382</parent_ref_id>
+    <ref_id>58960DD5BE3B49E1ACBFDFC2C11C745A</ref_id>
+    <sort_order>512</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="263D0C4628974C32B99AFE7B8BFE808D" action="add">
+    <child_ref_id>AE893D13EFCF4F269AB75D5413BE4E3C</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="related_id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>929CBE2034254E3A83BB391A667F3382</parent_ref_id>
+    <ref_id>222DFB3AB6B8437BA6907AC310E6B881</ref_id>
+    <sort_order>640</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="8F8AA643F1824D03B67E1AB417E4C25D" action="add">
+    <child_ref_id>C904BD5E210F4CAE84F2FED426AA6A74</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>929CBE2034254E3A83BB391A667F3382</parent_ref_id>
+    <ref_id>C61A375D0827447A8D3F2C7188DE4D43</ref_id>
+    <sort_order>1024</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="A4DF3CC2B47C44D884A917F9DB7A0930" action="add">
+    <child_ref_id>766DBE4DCA0F46A1B74BB03D5DFDCF8D</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="source_id" />
+		<property name="id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>3E2414194D5E4BD3BEF58879E7BBA459</parent_ref_id>
+    <ref_id>1B789128C3F64E819497FAA07999164B</ref_id>
+    <sort_order>1408</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="471E3AE7509C4A89B113C919B0A0CFCA" action="add">
+    <child_ref_id>9C09DFE83A9E49DE84EB360C81650235</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="source_id" />
+		<property name="id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>AE893D13EFCF4F269AB75D5413BE4E3C</parent_ref_id>
+    <ref_id>28EFBFA9B60A468FA0800AF99FECE1CB</ref_id>
+    <sort_order>1536</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="3CB8D3061D2C46B08EB41B929C34C096" action="add">
+    <child_ref_id>877BBFDA8984409C975D6076D089F0D8</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="affected_id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>C904BD5E210F4CAE84F2FED426AA6A74</parent_ref_id>
+    <ref_id>73027DB5743D4B1DA077650DAC91B94B</ref_id>
+    <sort_order>1664</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="3ACB748310714B0DB4E69577A8EF04FB" action="add">
+    <child_ref_id>819FB380465D44119C3BEC1E36E5F355</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="new_item_id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>C904BD5E210F4CAE84F2FED426AA6A74</parent_ref_id>
+    <ref_id>85EDBC0853964013B911F6A4B703656C</ref_id>
+    <sort_order>1792</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="47BDE7CA84304DE0850EF277781E44AF" action="add">
+    <child_ref_id>AB3113CFDF694029BE9217B52D4AF669</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="related_id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>877BBFDA8984409C975D6076D089F0D8</parent_ref_id>
+    <ref_id>A5CF5201E0814112B65341BCE46CDD45</ref_id>
+    <sort_order>1920</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="24ADE9AADBD64AAABBE3260E73472A05" action="add">
+    <child_ref_id>3488D8378E1B4187A43FAF41C43AD366</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="id" />
+		<property name="related_id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>819FB380465D44119C3BEC1E36E5F355</parent_ref_id>
+    <ref_id>A7D21A9E1BE942289283CBB14F32B54F</ref_id>
+    <sort_order>2048</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="10DA2A8301964E128DF4245A27A9792D" action="add">
+    <child_ref_id>89FA3907EB824F04A73DDDD72D824E4A</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="source_id" />
+		<property name="id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>AB3113CFDF694029BE9217B52D4AF669</parent_ref_id>
+    <ref_id>8C065B52F0AB4430AC7C0BC58C72CA4B</ref_id>
+    <sort_order>2176</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+   <Item type="qry_QueryReference" id="1905A0C2C6774CBF8F72E0627D7C07F5" action="add">
+    <child_ref_id>0E2BD3FC472C45309F11D10C1E998169</child_ref_id>
+    <filter_xml><![CDATA[<condition>
+	<eq>
+		<property query_items_xpath="parent::Item" name="source_id" />
+		<property name="id" />
+	</eq>
+</condition>]]></filter_xml>
+    <parent_ref_id>3488D8378E1B4187A43FAF41C43AD366</parent_ref_id>
+    <ref_id>D849A67818B4443AB3A210A1C67C882B</ref_id>
+    <sort_order>2304</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</source_id>
+   </Item>
+  </Relationships>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/rb_TreeGridViewDefinition/EXT_Part_BOMStructure.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/rb_TreeGridViewDefinition/EXT_Part_BOMStructure.xml
@@ -1,0 +1,177 @@
+﻿<AML>
+ <Item type="rb_TreeGridViewDefinition" id="539401D569884D3383051AA26991F46B" action="add">
+  <query_definition keyed_name="EXT_Part_BOMStructure" type="qry_QueryDefinition">A886F4A7966240A2A1D431F2F19480DB</query_definition>
+  <name>EXT_Part_BOMStructure</name>
+  <Relationships>
+   <Item type="rb_ColumnDefinition" id="A9294FBAD983470EA739448A2CBF4064" action="add">
+    <builder_method keyed_name="rb_DefaultColumnBuilderMethod" type="Method">AD1F071AA1B1437396D7ABCD67D10EA7</builder_method>
+    <header xml:lang="en">Part No.</header>
+    <name>Part BOM Structure</name>
+    <position_order>0</position_order>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+    <width>613</width>
+    <Relationships>
+     <Item type="rb_ColumnMapping" id="9895A15AC0554F40B1FD07960156E9A8" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="A9294FBAD983470EA739448A2CBF4064" type="rb_ColumnDefinition">A9294FBAD983470EA739448A2CBF4064</source_id>
+      <template>{"text_template":"{Part.id/@keyed_name} - {Part.name}","icon":"../images/Part.svg","item_id":"{Part.id}","item_type_name":"Part"}</template>
+      <tree_row_ref_id>2DE574C4A0F2441D94F8F1DE8C5773CF</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="818E4BCC37B248C2809E6CBC1CCB68D3" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="A9294FBAD983470EA739448A2CBF4064" type="rb_ColumnDefinition">A9294FBAD983470EA739448A2CBF4064</source_id>
+      <template>{"text_template":"{Part.id/@keyed_name} - {Part.name}","icon":"../images/Part.svg","item_type_name":"Part","item_id":"{Part.id}"}</template>
+      <tree_row_ref_id>5C119C1C74F948F5A98BE11E892FEBD0</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="B1ACDC70E2704EA4855EBA669B8983CE" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>512</sort_order>
+      <source_id keyed_name="A9294FBAD983470EA739448A2CBF4064" type="rb_ColumnDefinition">A9294FBAD983470EA739448A2CBF4064</source_id>
+      <template>{"text_template":"{Manufacturer Part.item_number} - {Manufacturer Part.manufacturer/@keyed_name}","item_type_name":"Manufacturer Part","item_id":"{Manufacturer Part.id}"}</template>
+      <tree_row_ref_id>A1E71DA404E4436AB158A31C018B8D69</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="2C618EB74FBD45CA94CE29A0F6805626" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>640</sort_order>
+      <source_id keyed_name="A9294FBAD983470EA739448A2CBF4064" type="rb_ColumnDefinition">A9294FBAD983470EA739448A2CBF4064</source_id>
+      <template>{"text_template":"{Document.id/@keyed_name}","item_type_name":"Document","item_id":"{Document.id}"}</template>
+      <tree_row_ref_id>4A19B17DE9B54361AB9FA3A46E3B12F3</tree_row_ref_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="rb_ColumnDefinition" id="03FA7BF9A19D46328878BE42BACB4300" action="add">
+    <builder_method keyed_name="rb_DefaultColumnBuilderMethod" type="Method">AD1F071AA1B1437396D7ABCD67D10EA7</builder_method>
+    <header xml:lang="en">Qty</header>
+    <name>D98B4CC885E04F7EB1C2359FA84EEB1F</name>
+    <position_order>1</position_order>
+    <sort_order>384</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+    <width>61</width>
+    <Relationships>
+     <Item type="rb_ColumnMapping" id="B57B95990E2841AAB51E84B3EDB33560" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="03FA7BF9A19D46328878BE42BACB4300" type="rb_ColumnDefinition">03FA7BF9A19D46328878BE42BACB4300</source_id>
+      <template>{"text_template":"{Part BOM.quantity}"}</template>
+      <tree_row_ref_id>2DE574C4A0F2441D94F8F1DE8C5773CF</tree_row_ref_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="rb_ColumnDefinition" id="C8ED3F70431F4B5984465ABC7B658D52" action="add">
+    <builder_method keyed_name="rb_DefaultColumnBuilderMethod" type="Method">AD1F071AA1B1437396D7ABCD67D10EA7</builder_method>
+    <name>993E25DE8FCC4A3696431B8B93459B58</name>
+    <position_order>3</position_order>
+    <sort_order>512</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+    <width>119</width>
+    <Relationships>
+     <Item type="rb_ColumnMapping" id="DA29293CE2AB460EBF6BD347D4CBEE56" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="C8ED3F70431F4B5984465ABC7B658D52" type="rb_ColumnDefinition">C8ED3F70431F4B5984465ABC7B658D52</source_id>
+      <template>{"text_template":"{Part.state}"}</template>
+      <tree_row_ref_id>5C119C1C74F948F5A98BE11E892FEBD0</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="9F5FB746BD6641889DE4EF63FB60395F" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="C8ED3F70431F4B5984465ABC7B658D52" type="rb_ColumnDefinition">C8ED3F70431F4B5984465ABC7B658D52</source_id>
+      <template>{"text_template":"{Part.state}"}</template>
+      <tree_row_ref_id>2DE574C4A0F2441D94F8F1DE8C5773CF</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="73CB32A57A064BC8B85AFE70E28B176E" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>384</sort_order>
+      <source_id keyed_name="C8ED3F70431F4B5984465ABC7B658D52" type="rb_ColumnDefinition">C8ED3F70431F4B5984465ABC7B658D52</source_id>
+      <template>{}</template>
+      <tree_row_ref_id>A1E71DA404E4436AB158A31C018B8D69</tree_row_ref_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="rb_ColumnDefinition" id="210308EA354B4DDDB9DE35234471922B" action="add">
+    <builder_method keyed_name="rb_DefaultColumnBuilderMethod" type="Method">AD1F071AA1B1437396D7ABCD67D10EA7</builder_method>
+    <header xml:lang="en">Unit</header>
+    <name>F7F37CF9B2E84882A057D14CB8295829</name>
+    <position_order>2</position_order>
+    <sort_order>768</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+    <width>47</width>
+    <Relationships>
+     <Item type="rb_ColumnMapping" id="07CFCC8BDC7E4B24AD08C623D0B0F8CE" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="210308EA354B4DDDB9DE35234471922B" type="rb_ColumnDefinition">210308EA354B4DDDB9DE35234471922B</source_id>
+      <template>{"text_template":"{Part.unit}"}</template>
+      <tree_row_ref_id>2DE574C4A0F2441D94F8F1DE8C5773CF</tree_row_ref_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="rb_TreeRowDefinition" id="A54976820D874C2DAB405C7DF7EE7C2D" action="add">
+    <query_item_ref_id>1A03431C6BB3412DA6CC8EC9652C3EEF</query_item_ref_id>
+    <ref_id>5C119C1C74F948F5A98BE11E892FEBD0</ref_id>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+   </Item>
+   <Item type="rb_TreeRowDefinition" id="1F955B2E2B1F4CBF85C27FDD1568DD65" action="add">
+    <query_item_ref_id>994020266FEB4B2EB5D94238AAC97E6D</query_item_ref_id>
+    <ref_id>2DE574C4A0F2441D94F8F1DE8C5773CF</ref_id>
+    <sort_order>256</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+   </Item>
+   <Item type="rb_TreeRowDefinition" id="E70DDBFCC0424DAD958A71FC924F70D6" action="add">
+    <query_item_ref_id>BE33AE7715CD4702BB2DA1B4C05D29F2</query_item_ref_id>
+    <ref_id>A1E71DA404E4436AB158A31C018B8D69</ref_id>
+    <sort_order>384</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+   </Item>
+   <Item type="rb_TreeRowDefinition" id="8B3380DAFA724DE3B2C58A6D914BFD67" action="add">
+    <query_item_ref_id>B777A2C9252B4AC69C6916F8AE986845</query_item_ref_id>
+    <ref_id>4A19B17DE9B54361AB9FA3A46E3B12F3</ref_id>
+    <sort_order>512</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+   </Item>
+   <Item type="rb_TreeRowReference" id="A765165E26424EF4B0CEBA8E85B51221" action="add">
+    <child_ref_id>5C119C1C74F948F5A98BE11E892FEBD0</child_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+    <view_order>128</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="C5A6EC60862E49F5B4AF18196E250C0D" action="add">
+    <child_ref_id>2DE574C4A0F2441D94F8F1DE8C5773CF</child_ref_id>
+    <parent_ref_id>5C119C1C74F948F5A98BE11E892FEBD0</parent_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>256</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+    <view_order>128</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="B0300D6E70CF42B3830601097B56EA0E" action="add">
+    <child_ref_id>5C119C1C74F948F5A98BE11E892FEBD0</child_ref_id>
+    <parent_ref_id>2DE574C4A0F2441D94F8F1DE8C5773CF</parent_ref_id>
+    <reference_type>join</reference_type>
+    <sort_order>384</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+    <view_order>128</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="B7EC419249404C6C82403D1FB6CA09E1" action="add">
+    <child_ref_id>A1E71DA404E4436AB158A31C018B8D69</child_ref_id>
+    <parent_ref_id>5C119C1C74F948F5A98BE11E892FEBD0</parent_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>512</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+    <view_order>256</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="C0640155CCC24612A7805E4A0EC10C17" action="add">
+    <child_ref_id>4A19B17DE9B54361AB9FA3A46E3B12F3</child_ref_id>
+    <parent_ref_id>5C119C1C74F948F5A98BE11E892FEBD0</parent_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>640</sort_order>
+    <source_id keyed_name="EXT_Part_BOMStructure" type="rb_TreeGridViewDefinition">539401D569884D3383051AA26991F46B</source_id>
+    <view_order>384</view_order>
+   </Item>
+  </Relationships>
+ </Item>
+</AML>

--- a/Imports/WhereUsed+BOMStructure/Import/rb_TreeGridViewDefinition/EXT_Part_WhereUsed.xml
+++ b/Imports/WhereUsed+BOMStructure/Import/rb_TreeGridViewDefinition/EXT_Part_WhereUsed.xml
@@ -1,0 +1,414 @@
+﻿<AML>
+ <Item type="rb_TreeGridViewDefinition" id="4537BD062A1548F79F22C2E8BD7BB170" action="add">
+  <query_definition keyed_name="EXT_Part_WhereUsed" type="qry_QueryDefinition">75DD65121EDE498F88FF7129720F3AA9</query_definition>
+  <name>EXT_Part_WhereUsed</name>
+  <Relationships>
+   <Item type="rb_ColumnDefinition" id="A518F77F5A7F4F218049624CF6F10248" action="add">
+    <builder_method keyed_name="rb_DefaultColumnBuilderMethod" type="Method">AD1F071AA1B1437396D7ABCD67D10EA7</builder_method>
+    <header xml:lang="en">Item No.</header>
+    <name>Part_WhereUsed</name>
+    <position_order>0</position_order>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <width>307</width>
+    <Relationships>
+     <Item type="rb_ColumnMapping" id="58F2B3878FDA426FB3FA5FDDE0F17109" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="A518F77F5A7F4F218049624CF6F10248" type="rb_ColumnDefinition">A518F77F5A7F4F218049624CF6F10248</source_id>
+      <template>{"text_template":"{Part.id/@keyed_name}","item_type_name":"Part","item_id":"{Part.id}"}</template>
+      <tree_row_ref_id>633417F340144319B6339DB7A99531B7</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="1B057C5C2B3849E2ABB00C0985F62EA1" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="A518F77F5A7F4F218049624CF6F10248" type="rb_ColumnDefinition">A518F77F5A7F4F218049624CF6F10248</source_id>
+      <template>{"text_template":"{Part.id/@keyed_name}","item_type_name":"Part","item_id":"{Part.id}","icon":"../images/Part.svg"}</template>
+      <tree_row_ref_id>7B9DF76339624209AF7AE86322B4BD9A</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="10378E3F467743209DFC47F84DA94B4A" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>384</sort_order>
+      <source_id keyed_name="A518F77F5A7F4F218049624CF6F10248" type="rb_ColumnDefinition">A518F77F5A7F4F218049624CF6F10248</source_id>
+      <template>{"text_template":"{mpp_ProcessPlan_1.id/@keyed_name}","item_type_name":"mpp_ProcessPlan","item_id":"{mpp_ProcessPlan_1.id}"}</template>
+      <tree_row_ref_id>EC5DC031685542C69655988D0344674B</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="ECC9F0F3F01546E7BED828CC7000D5F9" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>512</sort_order>
+      <source_id keyed_name="A518F77F5A7F4F218049624CF6F10248" type="rb_ColumnDefinition">A518F77F5A7F4F218049624CF6F10248</source_id>
+      <template>{"text_template":"{Simple MCO.item_number}","item_type_name":"Simple MCO","item_id":"{Simple MCO.id}","icon":""}</template>
+      <tree_row_ref_id>82047EEEE57949C5BD63EAACFFA73619</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="5E0EA5F740524DA0905608346ED4B7F4" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>768</sort_order>
+      <source_id keyed_name="A518F77F5A7F4F218049624CF6F10248" type="rb_ColumnDefinition">A518F77F5A7F4F218049624CF6F10248</source_id>
+      <template>{"text_template":"{Express ECO.id/@keyed_name}","item_type_name":"Express ECO","item_id":"{Express ECO.id}"}</template>
+      <tree_row_ref_id>363D78068F4F44B4B46540A094A10B11</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="10613D094E864F049880C0EF0C13DF15" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>896</sort_order>
+      <source_id keyed_name="A518F77F5A7F4F218049624CF6F10248" type="rb_ColumnDefinition">A518F77F5A7F4F218049624CF6F10248</source_id>
+      <template>{"text_template":"{Express ECO_1.id/@keyed_name}","item_type_name":"Express ECO","item_id":"{Express ECO_1.id}"}</template>
+      <tree_row_ref_id>67AC43DADB2E4B778915909A22D6666B</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="C7B797E2AA104E419BFDA66C57978CB2" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>1024</sort_order>
+      <source_id keyed_name="A518F77F5A7F4F218049624CF6F10248" type="rb_ColumnDefinition">A518F77F5A7F4F218049624CF6F10248</source_id>
+      <template>{"text_template":"{Part.id/@keyed_name}","item_type_name":"Part","item_id":"{Part.id}","icon":"../images/Part.svg"}</template>
+      <tree_row_ref_id>DD40C36E11774FF2AC7712717D734146</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="624BE7379A05477D8AA8D8AA956AA0A7" action="add">
+      <cell_view_type>Item</cell_view_type>
+      <sort_order>1152</sort_order>
+      <source_id keyed_name="A518F77F5A7F4F218049624CF6F10248" type="rb_ColumnDefinition">A518F77F5A7F4F218049624CF6F10248</source_id>
+      <template>{"text_template":"{Part.id/@keyed_name}","item_type_name":"Part","item_id":"{Part.id}"}</template>
+      <tree_row_ref_id>4AFF7546C8144BD483BB3A254F245E9B</tree_row_ref_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="rb_ColumnDefinition" id="287FCC9493F3402F8003FD67C36E7C27" action="add">
+    <builder_method keyed_name="rb_DefaultColumnBuilderMethod" type="Method">AD1F071AA1B1437396D7ABCD67D10EA7</builder_method>
+    <header xml:lang="en">Name</header>
+    <name>43BB7DDFEBC24552BE1B1D4CF04339EE</name>
+    <position_order>1</position_order>
+    <sort_order>640</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <width>424</width>
+    <Relationships>
+     <Item type="rb_ColumnMapping" id="3BB1ADE465B549EA8CA2839ECFA4BDEB" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="287FCC9493F3402F8003FD67C36E7C27" type="rb_ColumnDefinition">287FCC9493F3402F8003FD67C36E7C27</source_id>
+      <template>{"text_template":"{Part.name}"}</template>
+      <tree_row_ref_id>7B9DF76339624209AF7AE86322B4BD9A</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="14A1212DBC244AFE9B4F2342E0451758" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="287FCC9493F3402F8003FD67C36E7C27" type="rb_ColumnDefinition">287FCC9493F3402F8003FD67C36E7C27</source_id>
+      <template>{"text_template":"{Part.name}"}</template>
+      <tree_row_ref_id>633417F340144319B6339DB7A99531B7</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="0F57571D4C7F491494AC57016EBA1A67" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>384</sort_order>
+      <source_id keyed_name="287FCC9493F3402F8003FD67C36E7C27" type="rb_ColumnDefinition">287FCC9493F3402F8003FD67C36E7C27</source_id>
+      <template>{"text_template":"{Express ECO.title}"}</template>
+      <tree_row_ref_id>363D78068F4F44B4B46540A094A10B11</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="7F0DD0B6AB63497E9D63D4A222BCD1F8" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>512</sort_order>
+      <source_id keyed_name="287FCC9493F3402F8003FD67C36E7C27" type="rb_ColumnDefinition">287FCC9493F3402F8003FD67C36E7C27</source_id>
+      <template>{"text_template":"{Express ECO_1.title}"}</template>
+      <tree_row_ref_id>67AC43DADB2E4B778915909A22D6666B</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="BBC5F9F789784DEEB2AEBDA3DBA9B229" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>640</sort_order>
+      <source_id keyed_name="287FCC9493F3402F8003FD67C36E7C27" type="rb_ColumnDefinition">287FCC9493F3402F8003FD67C36E7C27</source_id>
+      <template>{"text_template":"{Simple MCO.title}"}</template>
+      <tree_row_ref_id>82047EEEE57949C5BD63EAACFFA73619</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="C389305BFDF44160AB17D3B54C87C5A3" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>768</sort_order>
+      <source_id keyed_name="287FCC9493F3402F8003FD67C36E7C27" type="rb_ColumnDefinition">287FCC9493F3402F8003FD67C36E7C27</source_id>
+      <template>{"text_template":"{Part.name}"}</template>
+      <tree_row_ref_id>4AFF7546C8144BD483BB3A254F245E9B</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="0A804D7391C84ABFB5941E3E6BCF4ED5" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>896</sort_order>
+      <source_id keyed_name="287FCC9493F3402F8003FD67C36E7C27" type="rb_ColumnDefinition">287FCC9493F3402F8003FD67C36E7C27</source_id>
+      <template>{"text_template":"{Part.name}"}</template>
+      <tree_row_ref_id>DD40C36E11774FF2AC7712717D734146</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="CE57CFA2A1E946E7A5D94749853637A2" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>1024</sort_order>
+      <source_id keyed_name="287FCC9493F3402F8003FD67C36E7C27" type="rb_ColumnDefinition">287FCC9493F3402F8003FD67C36E7C27</source_id>
+      <template>{"text_template":"{mpp_ProcessPlan_1.name}"}</template>
+      <tree_row_ref_id>EC5DC031685542C69655988D0344674B</tree_row_ref_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="rb_ColumnDefinition" id="9818952B9E8F418EBECF2EAD009EB841" action="add">
+    <builder_method keyed_name="rb_DefaultColumnBuilderMethod" type="Method">AD1F071AA1B1437396D7ABCD67D10EA7</builder_method>
+    <header xml:lang="en">State</header>
+    <name>A806AB8FBE23459F9ADB34E7F7EC8A88</name>
+    <position_order>4</position_order>
+    <sort_order>768</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <width>146</width>
+    <Relationships>
+     <Item type="rb_ColumnMapping" id="BA0B795E02D94006B3CA7CB841BAB1C2" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="9818952B9E8F418EBECF2EAD009EB841" type="rb_ColumnDefinition">9818952B9E8F418EBECF2EAD009EB841</source_id>
+      <template>{"text_template":"{Part.state}"}</template>
+      <tree_row_ref_id>633417F340144319B6339DB7A99531B7</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="BDC045825A7F48E9803B14D3C8B87783" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="9818952B9E8F418EBECF2EAD009EB841" type="rb_ColumnDefinition">9818952B9E8F418EBECF2EAD009EB841</source_id>
+      <template>{"text_template":"{Part.state}"}</template>
+      <tree_row_ref_id>7B9DF76339624209AF7AE86322B4BD9A</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="C76298E461D24B1CA686743B4C2108B2" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>384</sort_order>
+      <source_id keyed_name="9818952B9E8F418EBECF2EAD009EB841" type="rb_ColumnDefinition">9818952B9E8F418EBECF2EAD009EB841</source_id>
+      <template>{"text_template":"{Express ECO.state}"}</template>
+      <tree_row_ref_id>363D78068F4F44B4B46540A094A10B11</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="D36C02093B134F8C8CC1394B449951DA" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>512</sort_order>
+      <source_id keyed_name="9818952B9E8F418EBECF2EAD009EB841" type="rb_ColumnDefinition">9818952B9E8F418EBECF2EAD009EB841</source_id>
+      <template>{"text_template":"{Express ECO_1.state}"}</template>
+      <tree_row_ref_id>67AC43DADB2E4B778915909A22D6666B</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="94421B58D7AE4DBF8B7A4EDB6087167D" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>640</sort_order>
+      <source_id keyed_name="9818952B9E8F418EBECF2EAD009EB841" type="rb_ColumnDefinition">9818952B9E8F418EBECF2EAD009EB841</source_id>
+      <template>{"text_template":"{Simple MCO.state}"}</template>
+      <tree_row_ref_id>82047EEEE57949C5BD63EAACFFA73619</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="4BFF5A14435446D5950C761D24EA6822" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>768</sort_order>
+      <source_id keyed_name="9818952B9E8F418EBECF2EAD009EB841" type="rb_ColumnDefinition">9818952B9E8F418EBECF2EAD009EB841</source_id>
+      <template>{"text_template":"{Part.state}"}</template>
+      <tree_row_ref_id>DD40C36E11774FF2AC7712717D734146</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="F4391576DCFD4358BB9E08A6C02F559A" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>896</sort_order>
+      <source_id keyed_name="9818952B9E8F418EBECF2EAD009EB841" type="rb_ColumnDefinition">9818952B9E8F418EBECF2EAD009EB841</source_id>
+      <template>{"text_template":"{Part.state}"}</template>
+      <tree_row_ref_id>4AFF7546C8144BD483BB3A254F245E9B</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="78D4FE79AB9D4168ABB5668A9EC0B49D" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>1024</sort_order>
+      <source_id keyed_name="9818952B9E8F418EBECF2EAD009EB841" type="rb_ColumnDefinition">9818952B9E8F418EBECF2EAD009EB841</source_id>
+      <template>{"text_template":"{mpp_ProcessPlan_1.state}"}</template>
+      <tree_row_ref_id>EC5DC031685542C69655988D0344674B</tree_row_ref_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="rb_ColumnDefinition" id="2A267CEE192F415FA4781B87C0CE40B9" action="add">
+    <builder_method keyed_name="rb_DefaultColumnBuilderMethod" type="Method">AD1F071AA1B1437396D7ABCD67D10EA7</builder_method>
+    <header xml:lang="en">QTY</header>
+    <name>E5933FD2D4B746139EA176043CBE3C21</name>
+    <position_order>2</position_order>
+    <sort_order>1024</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <width>50</width>
+    <Relationships>
+     <Item type="rb_ColumnMapping" id="6265EF26413F4D288FA42BBCAEFF7169" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="2A267CEE192F415FA4781B87C0CE40B9" type="rb_ColumnDefinition">2A267CEE192F415FA4781B87C0CE40B9</source_id>
+      <template>{"text_template":"{Part BOM related_id.quantity}"}</template>
+      <tree_row_ref_id>7B9DF76339624209AF7AE86322B4BD9A</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="2A153F6AE7954991B8417C9E1C873D30" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="2A267CEE192F415FA4781B87C0CE40B9" type="rb_ColumnDefinition">2A267CEE192F415FA4781B87C0CE40B9</source_id>
+      <template>{"text_template":"{Part BOM related_id.quantity}"}</template>
+      <tree_row_ref_id>DD40C36E11774FF2AC7712717D734146</tree_row_ref_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="rb_ColumnDefinition" id="06CD84FAC8FB4FA0939DF43FA4164A0A" action="add">
+    <builder_method keyed_name="rb_DefaultColumnBuilderMethod" type="Method">AD1F071AA1B1437396D7ABCD67D10EA7</builder_method>
+    <header xml:lang="en">Reference Designator</header>
+    <name>992FC8CA03534A578D7E0C832807F16B</name>
+    <position_order>5</position_order>
+    <sort_order>1152</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <width>385</width>
+    <Relationships>
+     <Item type="rb_ColumnMapping" id="D5DDDDE005DF4C14BB7169FA9F8E0E53" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="06CD84FAC8FB4FA0939DF43FA4164A0A" type="rb_ColumnDefinition">06CD84FAC8FB4FA0939DF43FA4164A0A</source_id>
+      <template>{"text_template":"{Part BOM related_id.reference_designator}"}</template>
+      <tree_row_ref_id>7B9DF76339624209AF7AE86322B4BD9A</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="E39B4F43F4BD4D4C807B8AB12702A196" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="06CD84FAC8FB4FA0939DF43FA4164A0A" type="rb_ColumnDefinition">06CD84FAC8FB4FA0939DF43FA4164A0A</source_id>
+      <template>{"text_template":"{Part BOM related_id.reference_designator}"}</template>
+      <tree_row_ref_id>DD40C36E11774FF2AC7712717D734146</tree_row_ref_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="rb_ColumnDefinition" id="658715DB85E2459BB93014DABA8D3E14" action="add">
+    <builder_method keyed_name="rb_DefaultColumnBuilderMethod" type="Method">AD1F071AA1B1437396D7ABCD67D10EA7</builder_method>
+    <header xml:lang="en">Unit</header>
+    <name>BC79F1ACBC294ED3B2086F6DCB119B25</name>
+    <position_order>3</position_order>
+    <sort_order>1280</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <width>47</width>
+    <Relationships>
+     <Item type="rb_ColumnMapping" id="F3C45C6531A240ABA3E2C270EFE17D09" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="658715DB85E2459BB93014DABA8D3E14" type="rb_ColumnDefinition">658715DB85E2459BB93014DABA8D3E14</source_id>
+      <template>{"text_template":"{Part.unit}"}</template>
+      <tree_row_ref_id>7B9DF76339624209AF7AE86322B4BD9A</tree_row_ref_id>
+     </Item>
+     <Item type="rb_ColumnMapping" id="AE984D1F14AD4775895A4D9A7198FD26" action="add">
+      <cell_view_type>Text</cell_view_type>
+      <sort_order>256</sort_order>
+      <source_id keyed_name="658715DB85E2459BB93014DABA8D3E14" type="rb_ColumnDefinition">658715DB85E2459BB93014DABA8D3E14</source_id>
+      <template>{"text_template":"{Part.unit}"}</template>
+      <tree_row_ref_id>DD40C36E11774FF2AC7712717D734146</tree_row_ref_id>
+     </Item>
+    </Relationships>
+   </Item>
+   <Item type="rb_TreeRowDefinition" id="06714CB0E1C947DA9C8C3A55239E18E3" action="add">
+    <query_item_ref_id>929CBE2034254E3A83BB391A667F3382</query_item_ref_id>
+    <ref_id>4AFF7546C8144BD483BB3A254F245E9B</ref_id>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+   </Item>
+   <Item type="rb_TreeRowDefinition" id="6CDF94C6194849898BA692AED6EDFA15" action="add">
+    <query_item_ref_id>766DBE4DCA0F46A1B74BB03D5DFDCF8D</query_item_ref_id>
+    <ref_id>EC5DC031685542C69655988D0344674B</ref_id>
+    <sort_order>256</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+   </Item>
+   <Item type="rb_TreeRowDefinition" id="5FA202F0B585455AB9E549AB0C84006E" action="add">
+    <query_item_ref_id>9C09DFE83A9E49DE84EB360C81650235</query_item_ref_id>
+    <ref_id>82047EEEE57949C5BD63EAACFFA73619</ref_id>
+    <sort_order>384</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+   </Item>
+   <Item type="rb_TreeRowDefinition" id="034D694770314AD08F5FA4172C0B00CD" action="add">
+    <query_item_ref_id>89FA3907EB824F04A73DDDD72D824E4A</query_item_ref_id>
+    <ref_id>363D78068F4F44B4B46540A094A10B11</ref_id>
+    <sort_order>512</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+   </Item>
+   <Item type="rb_TreeRowDefinition" id="86E43298B40D438C89EF3176F834B5C3" action="add">
+    <query_item_ref_id>0E2BD3FC472C45309F11D10C1E998169</query_item_ref_id>
+    <ref_id>67AC43DADB2E4B778915909A22D6666B</ref_id>
+    <sort_order>640</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+   </Item>
+   <Item type="rb_TreeRowDefinition" id="BF3A30A1617F4EADB85ACD32ADE3C713" action="add">
+    <query_item_ref_id>91F8A554B1EA497FB556A07FB7D4B43C</query_item_ref_id>
+    <ref_id>DD40C36E11774FF2AC7712717D734146</ref_id>
+    <sort_order>768</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+   </Item>
+   <Item type="rb_TreeRowReference" id="145C480C024B4E71B58DBB0239C1CBEA" action="add">
+    <child_ref_id>633417F340144319B6339DB7A99531B7</child_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>128</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="81A454924523477D89284FDFC5BA3A29" action="add">
+    <child_ref_id>7B9DF76339624209AF7AE86322B4BD9A</child_ref_id>
+    <parent_ref_id>633417F340144319B6339DB7A99531B7</parent_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>256</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>128</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="521F800E1D1E4A26A1A4AEB381CFD97F" action="add">
+    <child_ref_id>633417F340144319B6339DB7A99531B7</child_ref_id>
+    <parent_ref_id>7B9DF76339624209AF7AE86322B4BD9A</parent_ref_id>
+    <reference_type>join</reference_type>
+    <sort_order>384</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>128</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="2362C59834684B04BA5A30A5FBFAA431" action="add">
+    <child_ref_id>671BC0D7CDDF4E499E06A72C14A65B51</child_ref_id>
+    <parent_ref_id>633417F340144319B6339DB7A99531B7</parent_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>1024</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>256</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="549B74DA2699433C8AFC4A104F0841B0" action="add">
+    <child_ref_id>3A3A0C9C923F431284BA89D914A97274</child_ref_id>
+    <parent_ref_id>671BC0D7CDDF4E499E06A72C14A65B51</parent_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>1152</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>128</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="488AE70615464649AE7AB313E1E8CDFF" action="add">
+    <child_ref_id>4AFF7546C8144BD483BB3A254F245E9B</child_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>1280</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>128</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="8933F76C262A4131BA9B801B3CE295D3" action="add">
+    <child_ref_id>82047EEEE57949C5BD63EAACFFA73619</child_ref_id>
+    <parent_ref_id>4AFF7546C8144BD483BB3A254F245E9B</parent_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>1664</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>38</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="A2F02A552F0C438EBFC212E3B559E90B" action="add">
+    <child_ref_id>363D78068F4F44B4B46540A094A10B11</child_ref_id>
+    <parent_ref_id>4AFF7546C8144BD483BB3A254F245E9B</parent_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>1920</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>30</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="F2761CC5DBF3482FAA3864AC12E57284" action="add">
+    <child_ref_id>67AC43DADB2E4B778915909A22D6666B</child_ref_id>
+    <parent_ref_id>4AFF7546C8144BD483BB3A254F245E9B</parent_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>2048</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>20</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="E9CD1033D0DC472FBC6C42B08F8AD70D" action="add">
+    <child_ref_id>EC5DC031685542C69655988D0344674B</child_ref_id>
+    <parent_ref_id>4AFF7546C8144BD483BB3A254F245E9B</parent_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>2304</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>10</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="31AF5E4086324E36A31E31388D6CF2E3" action="add">
+    <child_ref_id>DD40C36E11774FF2AC7712717D734146</child_ref_id>
+    <parent_ref_id>4AFF7546C8144BD483BB3A254F245E9B</parent_ref_id>
+    <reference_type>child</reference_type>
+    <sort_order>2432</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>128</view_order>
+   </Item>
+   <Item type="rb_TreeRowReference" id="85AB279987BE4ADAA5AEB0A982412620" action="add">
+    <child_ref_id>4AFF7546C8144BD483BB3A254F245E9B</child_ref_id>
+    <parent_ref_id>DD40C36E11774FF2AC7712717D734146</parent_ref_id>
+    <reference_type>join</reference_type>
+    <sort_order>2560</sort_order>
+    <source_id keyed_name="EXT_Part_WhereUsed" type="rb_TreeGridViewDefinition">4537BD062A1548F79F22C2E8BD7BB170</source_id>
+    <view_order>128</view_order>
+   </Item>
+  </Relationships>
+ </Item>
+</AML>

--- a/Imports/imports.mf
+++ b/Imports/imports.mf
@@ -1,3 +1,4 @@
 <imports>
   <package name="aras.labs.TGV_Sample" path="TGV_Sample\Import" />
+  <package name="ext.tgv.WhereUsed+BOMStructure" path="WhereUsed+BOMStructure\Import" />
 </imports>


### PR DESCRIPTION
Provides a customizable tgv version for an alternative Structure Browser/BOMStructure and Where Used. These two are probably one of the reasonable use cases for the query builder.

Standard Where used and Structure browser may return everything related to an Item, also Items that are not relevant for the end user. This version enhances the end user experience with a more compact and easier-to-read view. One of the main benefits is also the use of additional custom properties in the tgv. 

Notable features:
- Start tgv from CUI elements – Tgv can be started from Form AND Grid! Methods are designed to handle both use cases. 
- Shows how to add reverse PolyItems. This use case is not "ready-to-use" available in the standard Query Builder and needs some workaround. This version adds the Change Control Item to the query builder. 
- In the current version, not all available Change Processes are included. But additional Change Processes that use the "Affected Item” can easily be added from the Change Control Item
- Shows how to use init Method in CUI elements. This way, CUI buttons can be dynamically activated and disabled.
- “Where Used” sample uses customized sort_order - first show related Process Plans, than Change Processes, than Parts…

Remarks:
- Build with hybrid service pack SP11/SP12. 
- I use other icons but can not share them due to license restrictions. The currently used icons are therefore not the first choice and should be replaced by better ones.
- The “Reference id” property used for the ChangeControlledItem in the qry_QueryReference relationship is a manual assigned fake value. I doesn´t know the purpose of this property, neither were it comes from. The query works independent from this value. 
- The current version use the Item id instead of the config_id for retrieving the Change Items. The regular changes tab return all changes that happened during the Parts lifecycle. My version just returns the Changes that are relevant for the specific Item generation. It´s a matter of taste.